### PR TITLE
Fixed deleting a selection of row

### DIFF
--- a/src/ChildWidget.cpp
+++ b/src/ChildWidget.cpp
@@ -2405,7 +2405,7 @@ void ChildWidget::documentWasModified() {
 void ChildWidget::emitBoxChanged() {
   if (DMESS > 10) qDebug() << Q_FUNC_INFO;
   clearBalloons();
-  updateBalloons();
+  // updateBalloons();
   emit boxChanged();
 }
 
@@ -2529,7 +2529,7 @@ void ChildWidget::updateSelectionRects() {
       updateBalloons();
       resizer->setFromRect(modelItemBox()->rect().toRect());
     } else {
-      resizer->disable();
+      resizer->setFromRect(modelItemBox()->rect().toRect());
     }
   } else {
     clearBalloons();

--- a/src/ChildWidget.cpp
+++ b/src/ChildWidget.cpp
@@ -2261,8 +2261,10 @@ void ChildWidget::deleteSymbol() {
   int rowstodelete = indexes.size();
   int rownum = indexes.front().row();
 
-  for (int i = rowstodelete; i > 0; i--) {
-    deleteSymbolByRow(rownum);
+  while (!indexes.empty())
+  {
+    deleteSymbolByRow(indexes.back().row());
+    indexes.pop_back();
   }
 
   if (model->rowCount() != 0) {


### PR DESCRIPTION
Hi,

There was a bug when I tried to delete a selection of boxes (selected with Ctrl + mouse drag), the boxes deleted would be all wrong. This should fix it :)

Anthony