### PR TITLE
Added Mac OSX section

### DIFF
--- a/qt-box-editor.pro
+++ b/qt-box-editor.pro
@@ -1,5 +1,5 @@
 TEMPLATE = app
-VERSION = 1.12dev
+VERSION = 1.13dev
 TARGET = qt-box-editor-$${VERSION}
 
 DEPENDPATH += ./ \
@@ -60,7 +60,7 @@ RESOURCES = resources/application.qrc \
 
 LIBS += -llept -ltesseract
 
-win32: {
+win32 {
     DESTDIR = ./win32
     CONFIG += release embed_manifest_exe
     TMAKE_CXXFLAGS += -DQT_NODLL
@@ -73,11 +73,22 @@ win32: {
     LIBS += -lws2_32 -L$$PWD/win32-external/lib
 }
 
-unix: {
+unix:!macx {
+    message(Starting UNIX build...)
     greaterThan(QT_MAJOR_VERSION, 5) {
       message(Qt $$[QT_VERSION] was detected.)
       QT += widgets
       INCLUDEPATH += /opt/include/
       LIBS += -L/opt/lib
     }
+}
+
+# Libraries may be installed this way on Mac OS X:
+# brew install leptonica
+# brew install tesseract
+macx {
+    message(Starting OSX build...)
+    QT += widgets
+    INCLUDEPATH += /usr/local/include/
+    LIBS += -L/usr/local/lib
 }

--- a/qt-box-editor.pro
+++ b/qt-box-editor.pro
@@ -85,7 +85,7 @@ unix:!macx {
 
 # Libraries may be installed this way on Mac OS X:
 # brew install leptonica
-# brew install tesseract
+# brew install --training-tools --all-languages --HEAD https://gist.githubusercontent.com/fake-or-dead/8f1e817681847b689d2d/raw/915a5f6726a7aced6d75b902959fda1ae2d559c7/tesseract.rb
 macx {
     message(Starting OSX build...)
     QT += widgets

--- a/qt-box-editor.pro
+++ b/qt-box-editor.pro
@@ -86,6 +86,9 @@ unix:!macx {
 # Libraries may be installed this way on Mac OS X:
 # brew install leptonica
 # brew install --training-tools --all-languages --HEAD https://gist.githubusercontent.com/fake-or-dead/8f1e817681847b689d2d/raw/915a5f6726a7aced6d75b902959fda1ae2d559c7/tesseract.rb
+#
+# TESSDATE_PREFIX in the Settings of the App is: /usr/local/share/
+# Then close Settings and reopen Settings to select the language
 macx {
     message(Starting OSX build...)
     QT += widgets


### PR DESCRIPTION
1. Added Mac OSX section, based on lib installation of `leptonica` and `tesseract` via `brew`.
2. Removed trailing colons in `win23`- and `unix`- sections, which caused `make` command to ignore the respective configuration sections in question with Qt 5.5.0 on Mac OS X. The _new_ syntax is in accordance with Qt 4.8: [http://doc.qt.io/qt-4.8/qmake-advanced-usage.html]