### PR TITLE
Adding required libqt5svg5-dev dependency

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -21,6 +21,7 @@ sudo apt-get install qt5-qmake
 sudo apt-get install qt5-default
 sudo apt-get install libqt5gui5
 sudo apt-get install qt5-doc
+sudo apt-get install libqt5svg5-dev
  
 qmake -qt=5
 make


### PR DESCRIPTION
Without this dependency qmake returns:
`Project ERROR: Unknown module(s) in QT: svg`