### PR TITLE
Add install directory to qmake script

### DIFF
--- a/qt-box-editor.pro
+++ b/qt-box-editor.pro
@@ -15,6 +15,9 @@ INCLUDEPATH += ./ \
 
 QT += network svg
 
+INSTALLS += target
+target.path = $$PREFIX/bin
+
 CONFIG(debug, debug|release) {
     CONFIG += debug warn_on
     DESTDIR = debug


### PR DESCRIPTION
Was building https://github.com/NixOS/nixpkgs/pull/64677 and had to add a custom install directory to the qmake script. This PR added PREFIX path to the install.